### PR TITLE
fix: prevent workspace icon overlaps and implement drag reset (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prevent app state reset when minimizing/restoring windows — windows are now hidden via CSS instead of unmounted from the DOM, preserving iframe navigation, video playback position, and PDF viewer state (including preventing PDF page unmounts and zoom level recalculation when minimized) ([#56](https://github.com/GabFiterman/sete-janelas/issues/56))
 - Restore minimized windows (like File Explorer) when double-clicking workspace directory shortcuts or launching them again ([#57](https://github.com/GabFiterman/sete-janelas/issues/57))
+- Prevent workspace desktop icon overlaps by enforcing fixed square bounding boxes, truncating long titles with ellipsis, and implementing AABB collision prevention on drag end ([#58](https://github.com/GabFiterman/sete-janelas/issues/58))
 
 ## [1.1.2] - 2026-06-05
 

--- a/src/components/workspace/components/icon-link-label/icon-link-label.scss
+++ b/src/components/workspace/components/icon-link-label/icon-link-label.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  justify-content: center;
+  justify-content: flex-start;
   padding: $spacing-sm;
   position: absolute;
   left: 0;
@@ -15,7 +15,9 @@
   text-align: center;
   text-decoration: none;
   text-shadow: -2px 2px 2px rgb(0, 0, 0);
-  width: 7em;
+  width: 120px;
+  height: 120px;
+  box-sizing: border-box;
 
   &:hover {
     background: linear-gradient(180deg, rgba(121, 210, 247, 0.15) 0%, rgba(152, 229, 237, 0.35) 100%);
@@ -24,13 +26,21 @@
   }
 
   .icon-container {
-    max-width: 7em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    height: 100%;
   }
 
   .icon-image {
-    padding: $spacing-xs;
-    width: min-content;
-    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 60px;
+    width: 100%;
+    margin-bottom: 4px;
   }
 
   &.selected {
@@ -40,14 +50,30 @@
 
   .label {
     word-break: break-word;
+    font-size: 0.8rem;
+    line-height: 1.25;
+    margin-top: 4px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+    max-height: 2.5em;
   }
 
   @media (max-width: 767px) {
-    width: 5.5em;
+    width: 90px;
+    height: 90px;
     padding: $spacing-xs;
 
+    .icon-image {
+      height: 45px;
+    }
+
     .label {
-      font-size: 0.8rem;
+      font-size: 0.75rem;
+      max-height: 2.4em;
     }
   }
 }

--- a/src/components/workspace/components/icon-link-label/icon-link-label.tsx
+++ b/src/components/workspace/components/icon-link-label/icon-link-label.tsx
@@ -195,6 +195,7 @@ function IconLinkLabel({ className, constraintsRef, icon, size = '6vh' }: IconLi
       onClick={(event) => handleSingleClick(event)}
       dragConstraints={constraintsRef}
       drag={!isMobile}
+      title={`${label}${type === 'file' && extension ? extension : ''}`}
       style={{
         x: x,
         y: y,

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -30,7 +30,13 @@ function Workspace() {
 
         <div className="workspace-canvas-icons" ref={constraintsRef}>
           {workspaceIcons.map((workspaceIcon) => {
-            return <IconLinkLabel key={workspaceIcon.path} icon={workspaceIcon} constraintsRef={constraintsRef} />;
+            return (
+              <IconLinkLabel
+                key={`${workspaceIcon.path}_${workspaceIcon.dragVersion ?? 0}`}
+                icon={workspaceIcon}
+                constraintsRef={constraintsRef}
+              />
+            );
           })}
         </div>
       </div>

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -6,6 +6,7 @@ import { ITEMS_MAP_WORKSPACE, type FileSystemItem } from '@/constants';
 export interface WorkspaceIcon extends FileSystemItem {
   x: number;
   y: number;
+  dragVersion?: number;
 }
 
 export interface WindowState {
@@ -94,6 +95,7 @@ const useUIStore = create<UIState>((set, get) => ({
     ...item,
     x: (index % 2) * 150,
     y: Math.floor(index / 2) * 150,
+    dragVersion: 0,
   })),
 
   isBooting: true,
@@ -283,13 +285,31 @@ const useUIStore = create<UIState>((set, get) => ({
   updateWorkspaceIconPosition: (path, newX, newY) =>
     set((state) => {
       const { viewport, CONSTANTS } = state;
+      const isMobileDevice = viewport.width < 768;
+      const size = isMobileDevice ? 90 : 120;
 
-      const clampedX = Math.max(0, Math.min(newX, viewport.width - 80));
-      const clampedY = Math.max(0, Math.min(newY, viewport.height - CONSTANTS.FIXED_MENU_HEIGHT - 80));
+      const clampedX = Math.max(0, Math.min(newX, viewport.width - size));
+      const clampedY = Math.max(0, Math.min(newY, viewport.height - CONSTANTS.FIXED_MENU_HEIGHT - size));
+
+      // Checa colisão com os outros ícones
+      const COLLISION_THRESHOLD = size;
+      const hasCollision = state.workspaceIcons.some((icon) => {
+        if (icon.path === path) return false;
+        return Math.abs(clampedX - icon.x) < COLLISION_THRESHOLD && Math.abs(clampedY - icon.y) < COLLISION_THRESHOLD;
+      });
+
+      if (hasCollision) {
+        // Rejeita a alteração mas incrementa dragVersion para resetar o offset visual do drag
+        return {
+          workspaceIcons: state.workspaceIcons.map((icon) =>
+            icon.path === path ? { ...icon, dragVersion: (icon.dragVersion ?? 0) + 1 } : icon
+          ),
+        };
+      }
 
       return {
         workspaceIcons: state.workspaceIcons.map((icon) =>
-          icon.path === path ? { ...icon, x: clampedX, y: clampedY } : icon
+          icon.path === path ? { ...icon, x: clampedX, y: clampedY, dragVersion: (icon.dragVersion ?? 0) + 1 } : icon
         ),
       };
     }),


### PR DESCRIPTION
Este Pull Request soluciona o problema de sobreposição e colisão visual entre os ícones da área de trabalho (Workspace) do portfólio (#58).

## 🛠️ Alterações Realizadas

### 1. Prevenção de Colisão Reativa (AABB) & Reset do Offset de Drag
* **`uiStore.ts`:**
  * Adicionado o controle `dragVersion` na interface `WorkspaceIcon` e inicializado em `0`.
  * Na action `updateWorkspaceIconPosition`, implementada a detecção de colisão AABB de 2D com base no tamanho do ícone (120px em desktop / 90px em mobile).
  * Caso ocorra colisão, a nova coordenada é rejeitada, mas incrementamos a `dragVersion` do ícone.
  * O mesmo incremento ocorre quando o movimento é feito com sucesso.
* **`workspace.tsx`:**
  * Atualizada a propriedade `key` do componente `<IconLinkLabel>` para agregar a `dragVersion` (ex: `key={`${workspaceIcon.path}_${workspaceIcon.dragVersion ?? 0}`).
  * Isso força o React a remontar o componente no DOM ao término do arraste, limpando os offsets internos do Framer Motion e forçando o ícone a retornar visualmente (efeito snapback) para a sua coordenada original caso a colisão ocorra.

### 2. Dimensões Fixas e Limitação de Texto (CSS/SCSS)
* **`icon-link-label.scss`:**
  * Padronizado o tamanho dos ícones na Workspace com dimensões fixas de `120x120px` (desktop) e `90x90px` (mobile).
  * Aplicada limitação nos rótulos de texto de no máximo 2 linhas usando `-webkit-line-clamp` com reticências (`...`) automáticas caso o texto exceda a caixa.
* **`icon-link-label.tsx`:**
  * Adicionado o atributo `title` nativo do HTML para exibir o nome completo e extensão do arquivo como tooltip nativo ao passar o mouse (desktop) ou manter pressionado (mobile).

### 3. Changelog
* Nova entrada correspondente adicionada no `CHANGELOG.md`.

---

## 🧪 Verificação Realizada
* O build (`npm run build`) compilou com sucesso.
* Verificado manualmente que arrastar um ícone por cima de outro faz com que ele snappe de volta à posição anterior.
* Nomes longos agora quebram corretamente em até 2 linhas e exibem tooltip reativo.